### PR TITLE
Configure read timeout in URLConnections

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Avatar Ui Plug-in
 Bundle-SymbolicName: org.github.avatar.ui;singleton:=true
-Bundle-Version: 1.0.2
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.github.avatar.ui.AvatarPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -7,6 +7,6 @@ Bundle-Activator: org.github.avatar.ui.AvatarPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.github.avatar.ui
 Bundle-Vendor: B2i Healthcare

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.b2international</groupId>
 	<artifactId>org.github.avatar.ui</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
@@ -43,8 +43,8 @@
 				<artifactId>tycho-compiler-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/org/github/avatar/ui/AvatarFileStore.java
+++ b/src/org/github/avatar/ui/AvatarFileStore.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
  *  Copyright (c) 2011 GitHub Inc.
+ *  Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ *  
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +9,7 @@
  *
  *  Contributors:
  *    Kevin Sawicki (GitHub Inc.) - initial API and implementation
+ *    András Péteri (B2i Healthcare) - Use try-with-resources
  *******************************************************************************/
 package org.github.avatar.ui;
 
@@ -47,8 +50,9 @@ public class AvatarFileStore {
 	 * @param bundle
 	 */
 	public AvatarFileStore(Bundle bundle) {
-		this(Platform.getStateLocation(bundle).append(DEFAULT_STORE_NAME)
-				.toFile());
+		this(Platform.getStateLocation(bundle)
+			.append(DEFAULT_STORE_NAME)
+			.toFile());
 	}
 
 	/**
@@ -59,19 +63,15 @@ public class AvatarFileStore {
 	 * @throws ClassNotFoundException
 	 */
 	public AvatarStore load() throws IOException, ClassNotFoundException {
-		if (!file.exists())
+		if (!file.exists()) {
 			return null;
+		}
 
-		ObjectInputStream stream = null;
-		try {
-			stream = new ObjectInputStream(new FileInputStream(file));
-			return (AvatarStore) stream.readObject();
-		} finally {
-			if (stream != null)
-				try {
-					stream.close();
-				} catch (IOException ignore) {
-				}
+		try (
+			final FileInputStream inputStream = new FileInputStream(file);
+			final ObjectInputStream objectStream = new ObjectInputStream(inputStream);
+		) {
+			return (AvatarStore) objectStream.readObject();
 		}
 	}
 
@@ -83,18 +83,13 @@ public class AvatarFileStore {
 	 * @throws IOException
 	 */
 	public AvatarFileStore save(AvatarStore avatars) throws IOException {
-		ObjectOutputStream stream = null;
-		try {
-			stream = new ObjectOutputStream(new FileOutputStream(file));
-			stream.writeObject(avatars);
-		} finally {
-			if (stream != null)
-				try {
-					stream.close();
-				} catch (IOException ignore) {
-				}
+		try (
+			final FileOutputStream outputStream = new FileOutputStream(file);
+			final ObjectOutputStream objectStream = new ObjectOutputStream(outputStream);
+		) {
+			objectStream.writeObject(avatars);
 		}
+		
 		return this;
 	}
-
 }

--- a/src/org/github/avatar/ui/AvatarPlugin.java
+++ b/src/org/github/avatar/ui/AvatarPlugin.java
@@ -70,6 +70,8 @@ public class AvatarPlugin extends AbstractUIPlugin {
 
 		try {
 			this.store = new AvatarFileStore(context.getBundle()).load();
+			// Always use the compiled constant, not the value stored in the serialized instance
+			this.store.setUrl(AvatarStore.URL);
 		} catch (IOException e) {
 			log(Messages.AvatarPlugin_ExceptionLoadingStore, e);
 		} catch (ClassNotFoundException cnfe) {

--- a/src/org/github/avatar/ui/AvatarPlugin.java
+++ b/src/org/github/avatar/ui/AvatarPlugin.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
  *  Copyright (c) 2011 Kevin Sawicki
+ *  Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ *  
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -42,13 +44,13 @@ public class AvatarPlugin extends AbstractUIPlugin {
 	private static AvatarPlugin plugin;
 
 	private AvatarStore store;
-	private ServiceRegistration storeRegistration;
+	
+	private ServiceRegistration<IAvatarStore> storeRegistration;
 
 	/**
 	 * The constructor
 	 */
-	public AvatarPlugin() {
-	}
+	public AvatarPlugin() { }
 
 	/**
 	 * Get avatar store
@@ -73,11 +75,13 @@ public class AvatarPlugin extends AbstractUIPlugin {
 		} catch (ClassNotFoundException cnfe) {
 			log(Messages.AvatarPlugin_ExceptionLoadingStore, cnfe);
 		}
-		if (this.store == null)
+		
+		if (this.store == null) {
 			this.store = new AvatarStore();
+		}
 
-		this.storeRegistration = context.registerService(
-				IAvatarStore.class.getName(), this.store, null);
+		// Using parameterized service registration method
+		this.storeRegistration = context.registerService(IAvatarStore.class, this.store, null);
 	}
 
 	private void log(String message, Throwable throwable) {
@@ -86,8 +90,7 @@ public class AvatarPlugin extends AbstractUIPlugin {
 	}
 
 	/**
-	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext
-	 *      )
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
 	 */
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
@@ -113,5 +116,4 @@ public class AvatarPlugin extends AbstractUIPlugin {
 	public static AvatarPlugin getDefault() {
 		return plugin;
 	}
-
 }

--- a/src/org/github/avatar/ui/AvatarStore.java
+++ b/src/org/github/avatar/ui/AvatarStore.java
@@ -109,15 +109,20 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	 * @param url
 	 */
 	public AvatarStore(String url) {
-		Assert.isNotNull(url, "Url cannot be null"); //$NON-NLS-1$
+		setUrl(url);
+		this.avatars = Collections.synchronizedMap(new HashMap<String, Avatar>());
+	}
 
+	@Override
+	public void setUrl(String url) {
+		Assert.isNotNull(url, "Url cannot be null"); //$NON-NLS-1$
+	
 		// Ensure trailing slash
 		if (!url.endsWith("/")) { //$NON-NLS-1$
 			url += "/"; //$NON-NLS-1$
 		}
 		
 		this.url = url;
-		this.avatars = Collections.synchronizedMap(new HashMap<String, Avatar>());
 	}
 
 	/**

--- a/src/org/github/avatar/ui/AvatarStore.java
+++ b/src/org/github/avatar/ui/AvatarStore.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
  *  Copyright (c) 2011 Kevin Sawicki
+ *  Copyright 2024 B2i Healthcare, https://b2ihealthcare.com
+ *  
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -9,7 +11,6 @@
 package org.github.avatar.ui;
 
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -20,24 +21,21 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
-import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 
 /**
  * Class that loads and stores avatars.
+ * <p>
+ * Relevant pages that document the service:
+ * <ul>
+ * <li><a href="https://docs.gravatar.com/general/hash/">https://docs.gravatar.com/general/hash/</a>
+ * <li><a href="https://docs.gravatar.com/general/images/">https://docs.gravatar.com/general/images/</a>
+ * </ul>
  * 
  * @author Kevin Sawicki (kevin@github.com)
  */
@@ -46,12 +44,14 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	/**
 	 * URL
 	 */
-	public static final String URL = "https://www.gravatar.com/avatar/"; //$NON-NLS-1$
+	// The previous URL included the "www" prefix and used HTTP for the protocol
+	public static final String URL = "https://gravatar.com/avatar/"; //$NON-NLS-1$
 
 	/**
 	 * HASH_REGEX
 	 */
-	public static final String HASH_REGEX = "[0-9a-f]{32}"; //$NON-NLS-1$
+	// Changed from MD5 to SHA256 which uses 64 hex digits
+	public static final String HASH_REGEX = "[0-9a-f]{64}"; //$NON-NLS-1$
 
 	/**
 	 * HASH_PATTERN
@@ -61,27 +61,31 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	/**
 	 * HASH_LENGTH
 	 */
-	public static final int HASH_LENGTH = 32;
+	// Changed hash length from 32 to 64
+	public static final int HASH_LENGTH = 64;
+
+	/**
+	 * Zero-padded hexadecimal string, using HASH_LENGTH as its width
+	 */
+	// Added to simplify hex string conversion
+	private static final String FORMAT_PATTERN = "%0" + HASH_LENGTH + "x";
 
 	/**
 	 * HASH_ALGORITHM
 	 */
-	public static final String HASH_ALGORITHM = "MD5"; //$NON-NLS-1$
+	// Changed algorithm from MD5 to SHA256
+	public static final String HASH_ALGORITHM = "SHA256"; //$NON-NLS-1$
 
 	/**
 	 * TIMEOUT
 	 */
-	public static final int TIMEOUT = 2 * 1000;
-
-	/**
-	 * BUFFER_SIZE
-	 */
-	public static final int BUFFER_SIZE = 8192;
+	// Changed timeout to 1 second from 2 seconds
+	public static final int TIMEOUT = 1000;
 
 	/**
 	 * serialVersionUID
 	 */
-	private static final long serialVersionUID = 6084425297832914970L;
+	private static final long serialVersionUID = 2L;
 
 	/**
 	 * Charset used for hashing
@@ -106,9 +110,12 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	 */
 	public AvatarStore(String url) {
 		Assert.isNotNull(url, "Url cannot be null"); //$NON-NLS-1$
+
 		// Ensure trailing slash
-		if (!url.endsWith("/")) //$NON-NLS-1$
+		if (!url.endsWith("/")) { //$NON-NLS-1$
 			url += "/"; //$NON-NLS-1$
+		}
+		
 		this.url = url;
 		this.avatars = Collections.synchronizedMap(new HashMap<String, Avatar>());
 	}
@@ -132,12 +139,13 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	 */
 	public IAvatarStore scheduleRefresh() {
 		Job refresh = new Job(Messages.AvatarStore_RefreshJobName) {
-
+			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				refresh(monitor);
 				return Status.OK_STATUS;
 			}
 		};
+		
 		refresh.setRule(this);
 		refresh.schedule();
 		return this;
@@ -150,20 +158,27 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 		if (monitor == null) {
 			monitor = new NullProgressMonitor();
 		}
+		
 		String[] entries = null;
 		synchronized (this.avatars) {
 			entries = new String[this.avatars.size()];
 			entries = this.avatars.keySet().toArray(entries);
 		}
+		
 		monitor.beginTask("", entries.length); //$NON-NLS-1$
+		
 		for (String entry : entries) {
 			monitor.setTaskName(MessageFormat.format(Messages.AvatarStore_LoadingAvatar, entry));
+			
 			try {
 				loadAvatarByHash(entry);
 			} catch (IOException ignore) {
+				// It is not an issue if we can't fetch any of the avatars
 			}
+			
 			monitor.worked(1);
 		}
+		
 		monitor.done();
 		this.lastRefresh = System.currentTimeMillis();
 		return this;
@@ -180,33 +195,40 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	}
 
 	/**
-	 * @see org.github.avatar.ui.IAvatarStore#loadAvatarByHash(java.lang.String,
-	 *      org.github.avatar.ui.IAvatarCallback)
+	 * @see org.github.avatar.ui.IAvatarStore#loadAvatarByHash(java.lang.String, org.github.avatar.ui.IAvatarCallback)
 	 */
 	public IAvatarStore loadAvatarByHash(final String hash, final IAvatarCallback callback) {
 		String title = MessageFormat.format(Messages.AvatarStore_LoadingAvatar, hash);
 		Job job = new Job(title) {
-
+			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					Avatar avatar = loadAvatarByHash(hash);
-					if (avatar != null && callback != null)
+					
+					// Notify interested parties that the avatar was fetched successfully
+					if (avatar != null && callback != null) {
 						callback.loaded(avatar);
+					}
+					
 				} catch (IOException e) {
-					if (callback != null)
+
+					// Notify interested parties that an error occurred while fetching the avatar
+					if (callback != null) {
 						callback.error(e);
+					}
 				}
+				
 				return Status.OK_STATUS;
 			}
 		};
+		
 		job.setRule(this);
 		job.schedule();
 		return this;
 	}
 
 	/**
-	 * @see org.github.avatar.ui.IAvatarStore#loadAvatarByEmail(java.lang.String,
-	 *      org.github.avatar.ui.IAvatarCallback)
+	 * @see org.github.avatar.ui.IAvatarStore#loadAvatarByEmail(java.lang.String, org.github.avatar.ui.IAvatarCallback)
 	 */
 	public IAvatarStore loadAvatarByEmail(String email, IAvatarCallback callback) {
 		loadAvatarByHash(getHash(email), callback);
@@ -217,38 +239,35 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	 * @see org.github.avatar.ui.IAvatarStore#loadAvatarByHash(java.lang.String)
 	 */
 	public Avatar loadAvatarByHash(String hash) throws IOException {
-		if (!isValidHash(hash))
+		if (!isValidHash(hash)) {
 			return null;
+		}
 
 		Avatar avatar = null;
 		HttpURLConnection connection = (HttpURLConnection) new URL(this.url + hash).openConnection();
+
+		// Set both connection and read timeouts (originally just connection timeout was defined)
+		connection.setReadTimeout(TIMEOUT);
 		connection.setConnectTimeout(TIMEOUT);
 		connection.setUseCaches(false);
 		connection.connect();
 
-		if (connection.getResponseCode() != 200)
+		if (connection.getResponseCode() != 200) {
 			return null;
-
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		InputStream input = connection.getInputStream();
-		try {
-			byte[] buffer = new byte[BUFFER_SIZE];
-			int read = -1;
-			while ((read = input.read(buffer)) != -1)
-				output.write(buffer, 0, read);
-		} finally {
-			closeAndSwallowException(input);
-			closeAndSwallowException(output);
 		}
-		avatar = new Avatar(hash, System.currentTimeMillis(), output.toByteArray());
-		this.avatars.put(hash, avatar);
-		return avatar;
-	}
 
-	private void closeAndSwallowException(Closeable closable) {
-		try {
-			closable.close();
-		} catch (IOException e) {
+		try (
+			final InputStream inputStream = connection.getInputStream();
+			final ByteArrayOutputStream output = new ByteArrayOutputStream();
+		) {
+			// Use Java's built-in mechanism for transferring image data
+			inputStream.transferTo(output);
+			
+			long lastUpdated = System.currentTimeMillis();
+			avatar = new Avatar(hash, lastUpdated, output.toByteArray());
+			this.avatars.put(hash, avatar);
+			
+			return avatar;
 		}
 	}
 
@@ -267,20 +286,16 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	}
 
 	private String digest(String value) {
-		String hashed = null;
 		try {
-			byte[] digested = MessageDigest.getInstance(HASH_ALGORITHM).digest(value.getBytes(CHARSET));
-			hashed = new BigInteger(1, digested).toString(16);
-			int padding = HASH_LENGTH - hashed.length();
-			if (padding > 0) {
-				char[] zeros = new char[padding];
-				Arrays.fill(zeros, '0');
-				hashed = new String(zeros) + hashed;
-			}
+			MessageDigest algorithm = MessageDigest.getInstance(HASH_ALGORITHM);
+			byte[] input = value.getBytes(CHARSET);
+			byte[] digest = algorithm.digest(input);
+			
+			BigInteger digestNum = new BigInteger(1, digest);
+			return String.format(FORMAT_PATTERN, digestNum);
 		} catch (NoSuchAlgorithmException e) {
-			hashed = null;
+			return null;
 		}
-		return hashed;
 	}
 
 	/**
@@ -308,6 +323,11 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	 * @return hash
 	 */
 	public String getAdaptedHash(Object element) {
+		// Add early null check
+		if (element == null) {
+			return null;
+		}
+		
 		IAvatarHashProvider provider = null;
 		
 		if (element instanceof IAvatarHashProvider) {
@@ -318,15 +338,10 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 		
 		if (provider != null) {
 			return provider.getAvatarHash();
+		}
 
-		//added by bbanfai to avoid NPEs
-		} else if (element == null) {
-			return null;
-		}
-		else {
-			String potentialHash = element.toString();
-			return isValidHash(potentialHash) ? potentialHash : getHash(potentialHash);
-		}
+		String potentialHash = element.toString();
+		return isValidHash(potentialHash) ? potentialHash : getHash(potentialHash);
 	}
 
 	/**

--- a/src/org/github/avatar/ui/AvatarStore.java
+++ b/src/org/github/avatar/ui/AvatarStore.java
@@ -74,7 +74,7 @@ public class AvatarStore implements Serializable, ISchedulingRule, IAvatarStore 
 	 * HASH_ALGORITHM
 	 */
 	// Changed algorithm from MD5 to SHA256
-	public static final String HASH_ALGORITHM = "SHA256"; //$NON-NLS-1$
+	public static final String HASH_ALGORITHM = "SHA-256"; //$NON-NLS-1$
 
 	/**
 	 * TIMEOUT

--- a/src/org/github/avatar/ui/IAvatarStore.java
+++ b/src/org/github/avatar/ui/IAvatarStore.java
@@ -100,5 +100,12 @@ public interface IAvatarStore {
 	 * @return avatar or null if not in cache
 	 */
 	Avatar getAvatarByEmail(String email);
+	
+	/**
+	 * Sets the URL used for contacting the avatar service.
+	 * 
+	 * @param url
+	 */
+	void setUrl(String url);
 
 }


### PR DESCRIPTION
This PR is also part of a general improvement task and includes the following changes:

- Use SHA-256 for the message digest algorithm
- Use HTTPS and "www"-less service URL
- Use `String#format` for left-padded hexadecimal `BigInteger` to `String` conversion
- Use `InputStream#transferTo` method to pipe data to an output stream
- Increase required version of Java to 11 from 8